### PR TITLE
Move credentials to vault

### DIFF
--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,0 +1,4 @@
+{
+  "RPA_SECRET_MANAGER": "RPA.Robocloud.Secrets.FileSecrets",
+  "RPA_SECRET_FILE": "C:\\Users\\pc\\Documents\\Cursos\\Robocorp\\03_Software robot project workflow\\vault.json"
+}

--- a/tasks.robot
+++ b/tasks.robot
@@ -12,6 +12,7 @@ Library           RPA.Excel.Files
 Library           RPA.FileSystem
 Library           RPA.HTTP
 Library           RPA.PDF
+Library           RPA.Robocloud.Secrets
 
 *** Keywords ***
 Open The Intranet Website
@@ -19,8 +20,9 @@ Open The Intranet Website
 
 *** Keywords ***
 Log In
-    Input Text    id:username    maria
-    Input Password    id:password    thoushallnotpass
+    ${secret}=    Get Secret    robotsparebin
+    Input Text    id:username    ${secret}[username]
+    Input Password    id:password    ${secret}[password]
     Submit Form
     Wait Until Page Contains Element    id:sales-form
 


### PR DESCRIPTION
This pull request removes the hard-coded login credentials from the robot to a vault for better security.

To test this, create a vault.json file in your home directory (/Users/<your-username>). Paste the following JSON and update the value for the username and the password properties:

`{`
`  "robotsparebin": {`
`    "username": "username-here",`
`    "password": "password-here"`
`  }`
`}`

Update the path to the vault.json file in the devdata/json file.